### PR TITLE
Add quip categories mapping and lookup helpers

### DIFF
--- a/Configuration/QuipManager.cs
+++ b/Configuration/QuipManager.cs
@@ -6,6 +6,8 @@ internal static class QuipManager
 {
     public static IReadOnlyDictionary<int, CommandQuip> CommandQuips => _commandQuips;
     static readonly Dictionary<int, CommandQuip> _commandQuips = [];
+    static readonly Dictionary<string, List<CommandQuip>> _quipsByCategory = [];
+    const string DEFAULT_CATEGORY = "Default";
     public readonly struct CommandQuip(string name, string command)
     {
         public readonly LocalizationKey NameKey = LocalizationManager.GetLocalizationKey(name);
@@ -17,17 +19,25 @@ internal static class QuipManager
         public string Name { get; init; }
         public string InputString { get; init; }
     }
+    public static IEnumerable<string> GetCategories() => _quipsByCategory.Keys;
+    public static IReadOnlyList<CommandQuip> GetQuipsForCategory(string category) =>
+        _quipsByCategory.TryGetValue(category, out var quips) ? quips : Array.Empty<CommandQuip>();
     public static void TryLoadCommands()
     {
         var loaded = Persistence.LoadCommands();
 
         if (loaded != null)
         {
+            List<CommandQuip> defaultCategory = [];
             foreach (var keyValuePair in loaded)
             {
                 Command command = keyValuePair.Value;
-                _commandQuips.TryAdd(keyValuePair.Key, new CommandQuip(command.Name, command.InputString));
+                var commandQuip = new CommandQuip(command.Name, command.InputString);
+                _commandQuips.TryAdd(keyValuePair.Key, commandQuip);
+                defaultCategory.Add(commandQuip);
             }
+
+            if (defaultCategory.Count > 0) _quipsByCategory[DEFAULT_CATEGORY] = defaultCategory;
         }
     }
 }


### PR DESCRIPTION
## Summary
- map quip categories to their entries
- add helpers to fetch categories and category quips

## Testing
- `~/.dotnet/dotnet build`
- `PATH=$HOME/.dotnet:$PATH Configuration=Release ./dev_init.sh` *(fails: cannot create regular file '/tmp/bepinex/plugins')*


------
https://chatgpt.com/codex/tasks/task_e_68bc5de9f3ac832db0033ca7f184e30d