### PR TITLE
Reset action wheel category state on close

### DIFF
--- a/Patches/ActionWheelSystemPatch.cs
+++ b/Patches/ActionWheelSystemPatch.cs
@@ -173,20 +173,16 @@ internal static class ActionWheelSystemPatch
     [HarmonyPrefix]
     static bool HideCurrentWheelPrefix(ActionWheelSystem __instance)
     {
-        if (SocialWheelActive)
-        {
-            _inCategoryMode = true;
-            _activeCategory = string.Empty;
-            PopulateCategories();
-            return false;
-        }
-        else if (!_wheelOpened.Equals(DateTime.MinValue))
+        _inCategoryMode = true;
+        _activeCategory = string.Empty;
+        PopulateCategories();
+
+        if (!_wheelOpened.Equals(DateTime.MinValue))
         {
             _wheelOpened = DateTime.MinValue;
         }
 
-        // Core.Log.LogWarning($"[ActionWheelSystem.HideCurrentWheel]");
-        return true;
+        return !SocialWheelActive;
     }
 
     [HarmonyPatch(typeof(ActionWheelSystem), nameof(ActionWheelSystem.UpdateAndShowWheel))]


### PR DESCRIPTION
## Summary
- Clear active category and reset to category mode when hiding the action wheel

## Testing
- `.codex/install.sh`
- `./dev_init.sh` *(fails: error CS0120, CS1061, CS0029 in game-related types)*

------
https://chatgpt.com/codex/tasks/task_e_68bc73cb7b28832daa79c585916d8899