### PR TITLE
Load persisted command categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 
 ## Build & Testing
 
-* **Primary build command:** Run `dotnet build RetroCamera.csproj` from the repository root to validate changes compile.
-* **Record results:** Include the exact command and outcome in task reports. If the CLI is unavailable in the environment, note the failure explicitly instead of omitting the check.
+* **Bootstrap with the init script first:** From the repository root run `./scripts/init.sh` to install the expected .NET SDK (if missing), restore packages, and build in Release. Capture the full command output and note success or any environment-related failures.
+* **Direct builds remain valid:** When the `dotnet` CLI is already available, you may additionally run `dotnet build RetroCamera.csproj --configuration Release` from the repository root. Continue to report the exact command(s) and their outcomes.
 
 ---
 ## Strong Typing & Domain Modeling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@
 
 ---
 
+## Build & Testing
+
+* **Primary build command:** Run `dotnet build RetroCamera.csproj` from the repository root to validate changes compile.
+* **Record results:** Include the exact command and outcome in task reports. If the CLI is unavailable in the environment, note the failure explicitly instead of omitting the check.
+
+---
 ## Strong Typing & Domain Modeling
 
 * **Favor classes and structs over loose data structures:**  


### PR DESCRIPTION
## Summary
- load persisted command categories before refreshing the quip manager state
- copy saved quip entries into the in-memory dictionary and rebuild categories with SetCategory

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fabfafa9f4832d83f8f9d9eabe780e