### PR TITLE
Reset social wheel to categories on close

### DIFF
--- a/Patches/ActionWheelSystemPatch.cs
+++ b/Patches/ActionWheelSystemPatch.cs
@@ -110,13 +110,23 @@ internal static class ActionWheelSystemPatch
     [HarmonyPrefix]
     static bool HideCurrentWheelPrefix(ActionWheelSystem __instance)
     {
+        bool closingSocialWheel = SocialWheel != null && __instance?._CurrentActiveWheel == SocialWheel;
+        bool shouldResetWheel = SocialWheelActive || closingSocialWheel || ActiveCategory.HasValue;
+
+        if (shouldResetWheel)
+        {
+            ClearActiveCategory();
+            ShowCategoryMenu();
+        }
+
+        if (!_wheelOpened.Equals(DateTime.MinValue))
+        {
+            _wheelOpened = DateTime.MinValue;
+        }
+
         if (SocialWheelActive)
         {
             return false;
-        }
-        else if (!_wheelOpened.Equals(DateTime.MinValue))
-        {
-            _wheelOpened = DateTime.MinValue;
         }
 
         return true;

--- a/Systems/RetroCamera.cs
+++ b/Systems/RetroCamera.cs
@@ -377,6 +377,9 @@ public class RetroCamera : MonoBehaviour
 
         if (_socialWheelActive)
         {
+            ClearActiveCategory();
+            ShowCategoryMenu();
+
             _socialWheelActive = false;
             ActionWheelSystem.HideCurrentWheel();
             _socialWheel.gameObject.SetActive(false);


### PR DESCRIPTION
## Summary
- reset the command wheel state when HideCurrentWheel runs so the root category menu is ready the next time it opens
- reset the active category during SocialWheelKeyUp so the wheel always reopens at the category menu

## Testing
- ./scripts/init.sh *(fails: /workspace/RetroCamera/Systems/RetroCamera.cs(552,1): error CS1022: Type or namespace definition, or end-of-file expected)*

------
https://chatgpt.com/codex/tasks/task_e_68fb73873ac8832dbff88b461c12691f